### PR TITLE
Fix sg_config in config JSONs and cleanup keychain script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ python3 build-system/Make/Make.py \
 
 ## Xcode
 
-1. Copy and edit `build-system/appstore-configuration.json`.
+1. Copy and edit `build-system/appstore-configuration.json`. Ensure the JSON includes an `sg_config` key (set it to an empty string if you do not have custom Swiftgram configuration).
 2. Copy `build-system/fake-codesigning`. Create and download provisioning profiles, using the `profiles` folder as a reference for the entitlements.
 3. Generate an Xcode project:
 ```

--- a/build-system/Make/ImportCertificates.py
+++ b/build-system/Make/ImportCertificates.py
@@ -14,7 +14,7 @@ def import_certificates(certificatesPath):
 
     existing_keychains = run_executable_with_output('security', arguments=['list-keychains'], check_result=True)
     if keychain_name in existing_keychains:
-        run_executable_with_output('security', arguments=['delete-keychain'], check_result=True)
+        run_executable_with_output('security', arguments=['delete-keychain', keychain_name], check_result=True)
 
     run_executable_with_output('security', arguments=[
         'create-keychain',
@@ -24,7 +24,7 @@ def import_certificates(certificatesPath):
     ], check_result=True)
 
     existing_keychains = run_executable_with_output('security', arguments=['list-keychains', '-d', 'user'])
-    existing_keychains.replace('"', '')
+    existing_keychains = existing_keychains.replace('"', '').split()
 
     run_executable_with_output('security', arguments=[
         'list-keychains',
@@ -32,7 +32,7 @@ def import_certificates(certificatesPath):
         'user',
         '-s',
         keychain_name,
-        existing_keychains
+        *existing_keychains
     ], check_result=True)
 
     run_executable_with_output('security', arguments=['set-keychain-settings', keychain_name])

--- a/build-system/appcenter-configuration.json
+++ b/build-system/appcenter-configuration.json
@@ -1,5 +1,6 @@
 {
-	"bundle_id": "ph.telegra.Telegraph",
+        "sg_config": "",
+        "bundle_id": "ph.telegra.Telegraph",
 	"api_id": "8",
 	"api_hash": "7245de8e747a0d6fbe11f7cc14fcc0bb",
 	"team_id": "C67CF9S4VU",

--- a/build-system/appstore-configuration.json
+++ b/build-system/appstore-configuration.json
@@ -1,5 +1,6 @@
 {
-	"bundle_id": "ph.telegra.Telegraph",
+        "sg_config": "",
+        "bundle_id": "ph.telegra.Telegraph",
 	"api_id": "8",
 	"api_hash": "7245de8e747a0d6fbe11f7cc14fcc0bb",
 	"team_id": "C67CF9S4VU",


### PR DESCRIPTION
## Summary
- add `sg_config` field to example configuration files
- document `sg_config` requirement in README
- correct keychain deletion logic in ImportCertificates.py

## Testing
- `python3 -m py_compile build-system/Make/ImportCertificates.py`
- `python3 -m json.tool build-system/appstore-configuration.json`
- `python3 -m json.tool build-system/appcenter-configuration.json`


------
https://chatgpt.com/codex/tasks/task_e_6840b4313ca0832d8c461f3403ab0763