### PR TITLE
docs: clarify provisioning profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python3 build-system/Make/Make.py \
 ## Xcode
 
 1. Copy and edit `build-system/appstore-configuration.json`. Ensure the JSON includes an `sg_config` key (set it to an empty string if you do not have custom Swiftgram configuration).
-2. Copy `build-system/fake-codesigning`. Create and download provisioning profiles, using the `profiles` folder as a reference for the entitlements.
+2. Copy `build-system/fake-codesigning`. Create and download provisioning profiles, using the `profiles` folder as a reference for the entitlements. The sample profiles reference an Apple certificate that is not included in this repository. Create your own profiles using the certificates in `build-system/fake-codesigning/certs`; otherwise the build fails with an "Unable to find an identity" error.
 3. Generate an Xcode project:
 ```
 python3 build-system/Make/Make.py \


### PR DESCRIPTION
## Summary
- expand warning in README about sample provisioning profiles referencing a missing Apple certificate
- explain how to create new profiles using certificates under `build-system/fake-codesigning/certs`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c9580fe8832d8a127a977142c603