### PR TITLE
Document watchOS simulator requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ python3 build-system/Make/Make.py \
     --configuration=release_arm64
 ```
 
+Make sure the watchOS simulator runtimes are installed. Otherwise you may see
+
+```
+No available simulator runtimes for platform watchsimulator
+```
+
+If watchOS support isn't required, disable the watch targets in your
+configuration.
+
 # FAQ
 
 ## Xcode is stuck at "build-request.json not updated yet"


### PR DESCRIPTION
## Summary
- note that watchOS simulator runtimes must be installed for IPA builds
- mention the "No available simulator runtimes for platform watchsimulator" error
- advise disabling watch targets if watchOS isn't needed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c9593a44832db5519a0d80433b6f