### PR TITLE
Update README with submodule init instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ There are several things we require from **all developers** for the moment.
 git clone --recursive -j8 https://github.com/Swiftgram/Telegram-iOS.git
 ```
 
+If you cloned the repository without `--recursive`, fetch the submodules manually:
+
+```
+git submodule update --init --recursive
+```
+
+Missing submodules lead to errors such as `No MODULE.bazel… rules_xcodeproj`.
+
 ## Setup Xcode
 
 Install Xcode (directly from https://developer.apple.com/download/applications or using the App Store).


### PR DESCRIPTION
## Summary
- warn that missing submodules cause build errors
- show how to fetch submodules if the repo wasn't cloned with `--recursive`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840c95ad9f8832daaadc74cce3a4853