### PR TITLE
Enable extra Bazel args and extension-free builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ python3 build-system/Make/Make.py \
     --disableProvisioningProfiles
 ```
 
+## Build without extensions
+
+Skip compiling extensions by passing `--disableExtensions`:
+```
+python3 build-system/Make/Make.py \
+    --cacheDir="$HOME/telegram-bazel-cache" \
+    build \
+    --configurationPath=path-to-configuration.json \
+    --codesigningInformationPath=path-to-provisioning-data \
+    --buildNumber=100001 \
+    --configuration=release_arm64 \
+    --disableExtensions
+```
+
 ## Versions
 
 Each release is built using a specific Xcode version (see `versions.json`). The helper script checks the versions of the installed software and reports an error if they don't match the ones specified in `versions.json`. It is possible to bypass these checks:

--- a/build-system/Make/Make.py
+++ b/build-system/Make/Make.py
@@ -45,6 +45,7 @@ class BazelCommandLine:
         self.show_actions = False
         self.enable_sandbox = False
         self.disable_provisioning_profiles = False
+        self.disable_extensions = False
 
         self.common_args = [
             # https://docs.bazel.build/versions/master/command-line-reference.html
@@ -120,7 +121,11 @@ class BazelCommandLine:
         self.cache_dir = path
 
     def add_additional_args(self, additional_args):
-        self.additional_args = additional_args
+        if additional_args is None:
+            return
+        if self.additional_args is None:
+            self.additional_args = []
+        self.additional_args += shlex.split(additional_args)
 
     def set_build_number(self, build_number):
         self.build_number = build_number
@@ -145,6 +150,9 @@ class BazelCommandLine:
 
     def set_disable_provisioning_profiles(self):
         self.disable_provisioning_profiles = True
+
+    def set_disable_extensions(self):
+        self.disable_extensions = True
 
     def set_configuration(self, configuration):
         if configuration == 'debug_arm64':
@@ -207,6 +215,8 @@ class BazelCommandLine:
         combined_arguments = []
         if self.bazel_user_root is not None:
             combined_arguments += ['--output_user_root={}'.format(self.bazel_user_root)]
+        if self.additional_args is not None:
+            combined_arguments += self.additional_args
         return combined_arguments
 
     def invoke_clean(self):
@@ -262,6 +272,9 @@ class BazelCommandLine:
                 '--features=swift.split_derived_files_generation',
             ]
 
+        if self.additional_args is not None:
+            combined_arguments += self.additional_args
+
         return combined_arguments
 
     def invoke_build(self):
@@ -286,6 +299,8 @@ class BazelCommandLine:
 
         if self.disable_provisioning_profiles:
             combined_arguments += ['--//Telegram:disableProvisioningProfiles']
+        if self.disable_extensions:
+            combined_arguments += ['--//Telegram:disableExtensions']
 
         if self.configuration_path is None:
             raise Exception('configuration_path is not defined')
@@ -454,6 +469,9 @@ def clean(bazel, arguments):
         bazel_user_root=arguments.bazelUserRoot
     )
 
+    if arguments.bazelArguments is not None:
+        bazel_command_line.add_additional_args(arguments.bazelArguments)
+
     bazel_command_line.invoke_clean()
 
 
@@ -567,6 +585,12 @@ def generate_project(bazel, arguments):
     elif arguments.cacheHost is not None:
         bazel_command_line.add_remote_cache(arguments.cacheHost)
 
+    if arguments.bazelArguments is not None:
+        bazel_command_line.add_additional_args(arguments.bazelArguments)
+
+    if arguments.bazelArguments is not None:
+        bazel_command_line.add_additional_args(arguments.bazelArguments)
+
     bazel_command_line.set_continue_on_error(arguments.continueOnError)
 
     resolve_configuration(
@@ -640,6 +664,9 @@ def build(bazel, arguments):
     elif arguments.cacheHost is not None:
         bazel_command_line.add_remote_cache(arguments.cacheHost)
 
+    if arguments.bazelArguments is not None:
+        bazel_command_line.add_additional_args(arguments.bazelArguments)
+
     resolve_configuration(
         base_path=os.getcwd(),
         bazel_command_line=bazel_command_line,
@@ -653,6 +680,9 @@ def build(bazel, arguments):
     bazel_command_line.set_continue_on_error(arguments.continueOnError)
     bazel_command_line.set_show_actions(arguments.showActions)
     bazel_command_line.set_enable_sandbox(arguments.sandbox)
+
+    if arguments.disableExtensions:
+        bazel_command_line.set_disable_extensions()
 
     bazel_command_line.set_split_swiftmodules(arguments.enableParallelSwiftmoduleGeneration)
 
@@ -1033,6 +1063,12 @@ if __name__ == '__main__':
         action='store_true',
         default=False,
         help='Enable sandbox.',
+    )
+    buildParser.add_argument(
+        '--disableExtensions',
+        action='store_true',
+        default=False,
+        help='Do not build app extensions.',
     )
     buildParser.add_argument(
         '--outputBuildArtifactsPath',


### PR DESCRIPTION
## Summary
- allow passing additional bazel args to startup/build
- support `--disableExtensions` when building
- document how to build without extensions

## Testing
- `python3 -m py_compile build-system/Make/Make.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c95e436c832db0282de7690f4e22