### PR TITLE
Disable non‑iOS targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,16 @@ python3 build-system/Make/Make.py \
     --configuration=release_arm64
 ```
 
-Make sure the watchOS simulator runtimes are installed. Otherwise you may see
+watchOS build targets are disabled by default. Only the iOS application
+without extensions is compiled. If you need watch support, ensure the
+watchOS simulator runtimes are installed, otherwise you may see
 
 ```
 No available simulator runtimes for platform watchsimulator
 ```
 
-If watchOS support isn't required, disable the watch targets in your
-configuration.
+Set `telegram_enable_watch` to `True` and pass `--//Telegram:disableExtensions=False`
+when generating the project to enable watchOS targets.
 
 # FAQ
 

--- a/Telegram/BUILD
+++ b/Telegram/BUILD
@@ -68,7 +68,7 @@ config_setting(
 
 bool_flag(
     name = "disableExtensions",
-    build_setting_default = False,
+    build_setting_default = True,
     visibility = ["//visibility:public"],
 )
 

--- a/build-system/Make/BuildConfiguration.py
+++ b/build-system/Make/BuildConfiguration.py
@@ -55,7 +55,7 @@ class BuildConfiguration:
         string += 'telegram_aps_environment = "{}"\n'.format(aps_environment)
         string += 'telegram_enable_siri = {}\n'.format(self.enable_siri)
         string += 'telegram_enable_icloud = {}\n'.format(self.enable_icloud)
-        string += 'telegram_enable_watch = True\n'
+        string += 'telegram_enable_watch = False\n'
 
         if os.path.exists(path):
             os.remove(path)

--- a/build-system/example-configuration/variables.bzl
+++ b/build-system/example-configuration/variables.bzl
@@ -12,4 +12,4 @@ telegram_premium_iap_product_id = "org.telegram.telegramPremium.monthly"
 telegram_aps_environment = "production"
 telegram_enable_siri = True
 telegram_enable_icloud = True
-telegram_enable_watch = True
+telegram_enable_watch = False


### PR DESCRIPTION
## Summary
- disable app extensions by default
- stop generating watchOS build settings
- update sample configuration for no watchOS support
- note new defaults in documentation

## Testing
- `bazel --version` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840cc748310832d885287afb31ebbdd