### PR TITLE
Add watch configuration option

### DIFF
--- a/build-system/Make/BuildConfiguration.py
+++ b/build-system/Make/BuildConfiguration.py
@@ -21,7 +21,8 @@ class BuildConfiguration:
         app_specific_url_scheme,
         premium_iap_product_id,
         enable_siri,
-        enable_icloud
+        enable_icloud,
+        enable_watch
     ):
         self.sg_config = sg_config
         self.bundle_id = bundle_id
@@ -36,6 +37,7 @@ class BuildConfiguration:
         self.premium_iap_product_id = premium_iap_product_id
         self.enable_siri = enable_siri
         self.enable_icloud = enable_icloud
+        self.enable_watch = enable_watch
 
     def write_to_variables_file(self, bazel_path, use_xcode_managed_codesigning, aps_environment, path):
         string = ''
@@ -55,7 +57,7 @@ class BuildConfiguration:
         string += 'telegram_aps_environment = "{}"\n'.format(aps_environment)
         string += 'telegram_enable_siri = {}\n'.format(self.enable_siri)
         string += 'telegram_enable_icloud = {}\n'.format(self.enable_icloud)
-        string += 'telegram_enable_watch = False\n'
+        string += 'telegram_enable_watch = {}\n'.format(self.enable_watch)
 
         if os.path.exists(path):
             os.remove(path)
@@ -83,6 +85,7 @@ def build_configuration_from_json(path):
             'premium_iap_product_id',
             'enable_siri',
             'enable_icloud',
+            'enable_watch',
         ]
         for key in required_keys:
             if key not in configuration_dict:
@@ -101,6 +104,7 @@ def build_configuration_from_json(path):
             premium_iap_product_id=configuration_dict['premium_iap_product_id'],
             enable_siri=configuration_dict['enable_siri'],
             enable_icloud=configuration_dict['enable_icloud'],
+            enable_watch=configuration_dict['enable_watch'],
         )
 
 

--- a/build-system/appcenter-configuration.json
+++ b/build-system/appcenter-configuration.json
@@ -10,6 +10,7 @@
 	"appstore_id": "686449807",
 	"app_specific_url_scheme": "tg",
 	"premium_iap_product_id": "org.telegram.telegramPremium.monthly",
-	"enable_siri": true,
-	"enable_icloud": true
+        "enable_siri": true,
+        "enable_icloud": true,
+        "enable_watch": false
 }

--- a/build-system/appstore-configuration.json
+++ b/build-system/appstore-configuration.json
@@ -10,6 +10,7 @@
 	"appstore_id": "686449807",
 	"app_specific_url_scheme": "tg",
 	"premium_iap_product_id": "org.telegram.telegramPremium.monthly",
-	"enable_siri": true,
-	"enable_icloud": true
+        "enable_siri": true,
+        "enable_icloud": true,
+        "enable_watch": false
 }

--- a/build-system/template_minimal_development_configuration.json
+++ b/build-system/template_minimal_development_configuration.json
@@ -9,7 +9,8 @@
 	"appstore_id": "0",
 	"app_specific_url_scheme": "tg",
 	"premium_iap_product_id": "",
-	"enable_siri": false,
-	"enable_icloud": false,
-	"sg_config": ""
+        "enable_siri": false,
+        "enable_icloud": false,
+        "enable_watch": false,
+        "sg_config": ""
 }


### PR DESCRIPTION
## Summary
- support `enable_watch` in build configuration objects
- track watch flag in generated variables
- document `enable_watch` in example configs

## Testing
- `python3 -m py_compile build-system/Make/BuildConfiguration.py`
- `python3 -m py_compile build-system/Make/Make.py`
- `python3 -m py_compile build-system/Make/BuildEnvironment.py`
- `python3 -m json.tool build-system/appstore-configuration.json`
- `python3 -m json.tool build-system/appcenter-configuration.json`
- `python3 -m json.tool build-system/template_minimal_development_configuration.json`


------
https://chatgpt.com/codex/tasks/task_e_6840d048a690832da3f508044cfef90b