### PR TITLE
Add enable_watch setting support

### DIFF
--- a/build-system/Make/BuildConfiguration.py
+++ b/build-system/Make/BuildConfiguration.py
@@ -21,7 +21,8 @@ class BuildConfiguration:
         app_specific_url_scheme,
         premium_iap_product_id,
         enable_siri,
-        enable_icloud
+        enable_icloud,
+        enable_watch=False
     ):
         self.sg_config = sg_config
         self.bundle_id = bundle_id
@@ -36,6 +37,7 @@ class BuildConfiguration:
         self.premium_iap_product_id = premium_iap_product_id
         self.enable_siri = enable_siri
         self.enable_icloud = enable_icloud
+        self.enable_watch = enable_watch
 
     def write_to_variables_file(self, bazel_path, use_xcode_managed_codesigning, aps_environment, path):
         string = ''
@@ -55,7 +57,7 @@ class BuildConfiguration:
         string += 'telegram_aps_environment = "{}"\n'.format(aps_environment)
         string += 'telegram_enable_siri = {}\n'.format(self.enable_siri)
         string += 'telegram_enable_icloud = {}\n'.format(self.enable_icloud)
-        string += 'telegram_enable_watch = False\n'
+        string += 'telegram_enable_watch = {}\n'.format('True' if self.enable_watch else 'False')
 
         if os.path.exists(path):
             os.remove(path)
@@ -101,6 +103,7 @@ def build_configuration_from_json(path):
             premium_iap_product_id=configuration_dict['premium_iap_product_id'],
             enable_siri=configuration_dict['enable_siri'],
             enable_icloud=configuration_dict['enable_icloud'],
+            enable_watch=configuration_dict.get('enable_watch', False),
         )
 
 


### PR DESCRIPTION
## Summary
- support optional watch builds
- pass enable_watch flag when choosing configuration

## Testing
- `python3 -m py_compile build-system/Make/Make.py build-system/Make/BuildConfiguration.py`

------
https://chatgpt.com/codex/tasks/task_e_6840d0312d3c832d81d43327141b82f8