### PR TITLE
Add Docker build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/xcodeorg/xcode:16.2
+
+WORKDIR /telegram
+
+ENV BAZEL_CACHE_DIR=/tmp/telegram-bazel-cache \
+    BUILD_NUMBER=1 \
+    BUILD_CONFIGURATION=release_arm64 \
+    CONFIG_PATH=/tmp/build-config
+
+COPY . .
+
+ENTRYPOINT ["/bin/bash", "/telegram/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -82,8 +82,19 @@ python3 build-system/Make/Make.py \
     --configurationPath=...see previous section... \
     --codesigningInformationPath=...see previous section... \
     --buildNumber=100001 \
-    --configuration=release_arm64
+  --configuration=release_arm64
 ```
+
+## Docker Build
+
+You can build an unsigned IPA using Docker on macOS:
+
+```bash
+docker build -t swiftgram .
+docker run --rm -v $(pwd)/build:/telegram/build swiftgram
+```
+
+The resulting IPA will be available at `build/artifacts/Swiftgram.ipa`.
 
 # FAQ
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# create local configuration if not provided
+if [ ! -d "$CONFIG_PATH" ]; then
+  cp -R build-system/example-configuration "$CONFIG_PATH"
+fi
+
+mkdir -p "$BAZEL_CACHE_DIR"
+
+python3 build-system/Make/Make.py \
+    --cacheDir="$BAZEL_CACHE_DIR" \
+    build \
+    --configurationPath="$CONFIG_PATH" \
+    --disableProvisioningProfiles \
+    --configuration="$BUILD_CONFIGURATION" \
+    --buildNumber="$BUILD_NUMBER" \
+    --outputBuildArtifactsPath=build/artifacts


### PR DESCRIPTION
## Summary
- add a Dockerfile with Xcode 16.2 base image
- provide entrypoint script to build the IPA
- document Docker build usage in the README

## Testing
- `git status --short`
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684141a34014832d85b48b0b8aebc0d8