### PR TITLE
Add workflow for unsigned IPA build

### DIFF
--- a/.github/workflows/build-unsigned.yml
+++ b/.github/workflows/build-unsigned.yml
@@ -1,0 +1,62 @@
+name: Unsigned IPA Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-13
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          fetch-depth: '0'
+
+      - name: Set active Xcode path
+        run: |
+          XCODE_VERSION=$(python3 -c 'import json,sys;print(json.load(open("versions.json"))["xcode"])')
+          XCODE_PATH="/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer"
+          if [ -d "$XCODE_PATH" ]; then
+            sudo xcode-select -s "$XCODE_PATH"
+          else
+            echo "Desired Xcode $XCODE_VERSION not installed. Using default $(xcodebuild -version | head -n 1)" >&2
+          fi
+
+      - name: Create canonical source directory
+        run: |
+          sudo mkdir -p /Users/Shared
+          cp -R "$GITHUB_WORKSPACE" /Users/Shared/
+          mv /Users/Shared/$(basename "$GITHUB_WORKSPACE") /Users/Shared/telegram-ios
+
+      - name: Build IPA
+        run: |
+          set -ex
+          SOURCE_DIR=/Users/Shared/telegram-ios
+          BAZEL_USER_ROOT="/private/var/tmp/_bazel_$(whoami)"
+          cd "$SOURCE_DIR"
+
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          python3 build-system/Make/ImportCertificates.py --path build-system/fake-codesigning/certs
+          python3 -u build-system/Make/Make.py \
+            --bazelUserRoot="$BAZEL_USER_ROOT" \
+            build \
+            --configurationPath=build-system/example-configuration \
+            --codesigningInformationPath=build-system/fake-codesigning \
+            --configuration=release_arm64 \
+            --disableProvisioningProfiles \
+            --buildNumber="$BUILD_NUMBER" \
+            --outputBuildArtifactsPath=build/artifacts
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: Swiftgram.ipa
+          path: /Users/Shared/telegram-ios/build/artifacts/Swiftgram.ipa
+
+      - name: Upload DSYM
+        uses: actions/upload-artifact@v4
+        with:
+          name: Swiftgram.DSYMs.zip
+          path: /Users/Shared/telegram-ios/build/artifacts/Swiftgram.DSYMs.zip
+


### PR DESCRIPTION
## Summary
- add a workflow that builds the IPA without codesigning
- upload the resulting artifacts using GitHub Actions
- import fake certificates and provide fake codesigning path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68415d5a7d78832d9d50d545cceef7c6